### PR TITLE
Fix High Resolution Timer bug when the time is greater than one second

### DIFF
--- a/lib/metrics/Meter.js
+++ b/lib/metrics/Meter.js
@@ -100,5 +100,5 @@ Meter.prototype._getTime = function() {
   if (!process.hrtime) return Date.now();
 
   var hrtime = process.hrtime();
-  return hrtime[0] / 1000 + hrtime[1] / (1000 * 1000);
+  return hrtime[0] * 1000 + hrtime[1] / (1000 * 1000);
 };

--- a/lib/util/Stopwatch.js
+++ b/lib/util/Stopwatch.js
@@ -26,5 +26,5 @@ Stopwatch.prototype._getTime = function() {
   if (!process.hrtime) return Date.now();
 
   var hrtime = process.hrtime();
-  return hrtime[0] / 1000 + hrtime[1] / (1000 * 1000);
+  return hrtime[0] * 1000 + hrtime[1] / (1000 * 1000);
 };


### PR DESCRIPTION
The original code has a serious bug when process.hrtime() return a value that more than one second.
That's because the unit of the first element is SECOND.
