### PR TITLE
Add NoOpMeter, a meter that doesn't do anything, this is usful to use…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 1.4.0
+
+- Add NoOpMeter, a meter that doesn't do anything, this is usful to use in a Timer if you want access to the 
+  Stopwatch api for histogram data and don't want to deal with the overhead of a meter.
+
 ## 1.3.0
 
 - Add SettableGauge, a gauge that can have it's value set directly, useful for async situations

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const Gauge = require('./lib/metrics/Gauge');
 const SettableGauge = require('./lib/metrics/SettableGauge');
 const Histogram = require('./lib/metrics/Histogram');
 const Meter = require('./lib/metrics/Meter');
+const NoOpMeter = require('./lib/metrics/NoOpMeter');
 const Timer = require('./lib/metrics/Timer');
 const BinaryHeap = require('./lib/util/BinaryHeap');
 const ExponentiallyDecayingSample = require('./lib/util/ExponentiallyDecayingSample');
@@ -52,6 +53,12 @@ module.exports = {
    * @type {Meter}
    */
   Meter,
+
+  /**
+   * See {@link NoOpMeter}
+   * @type {NoOpMeter}
+   */
+  NoOpMeter,
 
   /**
    * See {@link Timer}

--- a/lib/metrics/NoOpMeter.js
+++ b/lib/metrics/NoOpMeter.js
@@ -1,0 +1,95 @@
+const { METRIC_TYPES } = require('./Metric');
+
+/**
+ * A No-Op Impl of Meter that can be used with a timer, to only create histogram data.
+ * This is useful for some time series aggregators that can calculate rates for you just off of sent count.
+ *
+ * @implements {Metric}
+ * @example
+ * const { NoOpMeter, Timer } = require('measured')
+ * const meter = new NoOpMeter();
+ * const timer = new Timer({meter: meter});
+ * ...
+ * // do some stuff with the timer and stopwatch api
+ * ...
+ */
+// eslint-disable-next-line padded-blocks
+class NoOpMeter {
+
+  /**
+   * No-Op impl
+   * @param {number} n Number of events to mark.
+   */
+  // eslint-disable-next-line no-unused-vars
+  mark(n) {
+
+  }
+
+  /**
+   * No-Op impl
+   */
+  start() {
+
+  }
+
+  /**
+   * No-Op impl
+   */
+  end() {
+
+  }
+
+  /**
+   * No-Op impl
+   */
+  ref() {
+
+  }
+
+  /**
+   * No-Op impl
+   */
+  unref() {
+
+  }
+
+  /**
+   * No-Op impl
+   */
+  reset() {
+
+  }
+
+  /**
+   * No-Op impl
+   */
+  meanRate() {
+
+  }
+
+  /**
+   * No-Op impl
+   */
+  currentRate() {
+
+  }
+
+  /**
+   * Returns an empty object
+   * @return {{}}
+   */
+  toJSON() {
+    return {
+
+    };
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getType() {
+    return METRIC_TYPES.METER;
+  }
+}
+
+module.exports = NoOpMeter;

--- a/test/unit/metrics/test-Counter.js
+++ b/test/unit/metrics/test-Counter.js
@@ -75,7 +75,6 @@ describe('Counter', function() {
   });
 
   it('returns the expected type', () => {
-    const counter = new common.measured.Counter();
     assert.equal(counter.getType(), 'Counter');
   })
 });

--- a/test/unit/metrics/test-Histogram.js
+++ b/test/unit/metrics/test-Histogram.js
@@ -28,6 +28,11 @@ describe('Histogram', function() {
     assert.strictEqual(json.p99, null);
     assert.strictEqual(json.p999, null);
   });
+
+
+  it('returns the expected type', () => {
+    assert.equal(histogram.getType(), 'Histogram');
+  })
 });
 
 describe('Histogram#update', function() {
@@ -251,9 +256,4 @@ describe('Histogram#hasValues', function() {
   it('has no values', function() {
     assert.equal(histogram.hasValues(), false);
   });
-
-  it('returns the expected type', () => {
-    const histogram = new common.measured.Histogram();
-    assert.equal(histogram.getType(), 'Histogram');
-  })
 });

--- a/test/unit/metrics/test-Meter.js
+++ b/test/unit/metrics/test-Meter.js
@@ -138,7 +138,6 @@ describe('Meter', function() {
   });
 
   it('returns the expected type', () => {
-    const meter = new common.measured.Meter();
     assert.equal(meter.getType(), 'Meter');
   })
 });

--- a/test/unit/metrics/test-NoOpMeter.js
+++ b/test/unit/metrics/test-NoOpMeter.js
@@ -1,0 +1,20 @@
+/*global describe, it, beforeEach, afterEach*/
+
+var common = require('../../common');
+var assert = require('assert');
+
+describe('NoOpMeter', () => {
+  let meter;
+
+  beforeEach(() => {
+    meter = new common.measured.NoOpMeter();
+  });
+
+  it ('always returns empty object', () => {
+    assert.deepEqual(meter.toJSON(), {});
+  })
+
+  it('returns the expected type', () => {
+    assert.equal(meter.getType(), 'Meter');
+  })
+});

--- a/test/unit/metrics/test-Timer.js
+++ b/test/unit/metrics/test-Timer.js
@@ -80,7 +80,6 @@ describe('Timer', function() {
   });
 
   it('returns the expected type', () => {
-    const timer = new common.measured.Timer();
     assert.equal(timer.getType(), 'Timer');
   })
 });


### PR DESCRIPTION
Add NoOpMeter, a meter that doesn't do anything, this is usful to use in a Timer if you want access to the Stopwatch api for histogram data and don't want to deal with the overhead of a meter.

@csabapalfi I wanted to let you merge this and run your ```npm version minor``` command.
What should happen once you merge is that the jsdocs get generated and published to the site.
After you run the npm command and a tag gets pushed, another build will be triggered that does the npm publishing.

https://travis-ci.org/yaorg/node-measured