### PR TITLE
Do not use Object.values(...)

### DIFF
--- a/packages/measured-core/lib/validators/metricValidators.js
+++ b/packages/measured-core/lib/validators/metricValidators.js
@@ -1,6 +1,8 @@
 const { MetricTypes } = require('../metrics/Metric');
 
-const metricTypeValues = Object.values(MetricTypes);
+// TODO: Object.values(...) does not exist in Node.js 6.x, switch after LTS period ends.
+// const metricTypeValues = Object.values(MetricTypes);
+const metricTypeValues = Object.keys(MetricTypes).map(key => MetricTypes[key]);
 
 /**
  * This module contains various validators to validate publicly exposed input.


### PR DESCRIPTION
The `Object.values(...)` function was not added until Node.js 7.x.
Use `Object.keys(...).map(...)` until the Node.js 6.x LTS expires.

Fixes #51