### PR TITLE
Test all active Node.js release lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-- lts/*
+- 11
+- 10
+- 8
+- 6
 before_install:
 - sudo apt-get -qq update
 - sudo apt-get install -y gawk jq


### PR DESCRIPTION
Rather than only testing the latest LTS, this will test _all_ active (supported) release.