### PR TITLE
Support all active Node.js release lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-- lts/*
+- 11
+- 10
+- 8
+- 6
 before_install:
 - sudo apt-get -qq update
 - sudo apt-get install -y gawk jq

--- a/packages/measured-core/lib/validators/metricValidators.js
+++ b/packages/measured-core/lib/validators/metricValidators.js
@@ -1,6 +1,8 @@
 const { MetricTypes } = require('../metrics/Metric');
 
-const metricTypeValues = Object.values(MetricTypes);
+// TODO: Object.values(...) does not exist in Node.js 6.x, switch after LTS period ends.
+// const metricTypeValues = Object.values(MetricTypes);
+const metricTypeValues = Object.keys(MetricTypes).map(key => MetricTypes[key]);
 
 /**
  * This module contains various validators to validate publicly exposed input.

--- a/packages/measured-core/test/unit/metrics/test-CachedGauge.js
+++ b/packages/measured-core/test/unit/metrics/test-CachedGauge.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 describe('CachedGauge', () => {
   let cachedGauge;
-  it('A cachedGauge immediately calls the callback to set its initial value', async () => {
+  it('A cachedGauge immediately calls the callback to set its initial value', () => {
     cachedGauge = new CachedGauge(
       () => {
         return new Promise(resolve => {
@@ -16,12 +16,12 @@ describe('CachedGauge', () => {
       TimeUnits.MINUTES
     ); // Shouldn't update in the unit test.
 
-    await wait(5 * TimeUnits.MILLISECONDS);
-
-    assert.equal(cachedGauge.toJSON(), 10);
+    return wait(5 * TimeUnits.MILLISECONDS).then(() => {
+      assert.equal(cachedGauge.toJSON(), 10);
+    });
   });
 
-  it('A cachedGauge calls the callback at the interval provided', async () => {
+  it('A cachedGauge calls the callback at the interval provided', () => {
     const values = [1, 2];
     cachedGauge = new CachedGauge(
       () => {
@@ -33,10 +33,10 @@ describe('CachedGauge', () => {
       TimeUnits.MILLISECONDS
     );
 
-    await wait(7 * TimeUnits.MILLISECONDS);
-
-    assert.equal(cachedGauge.toJSON(), 2);
-    assert.equal(values.length, 0, 'the callback should have been called 2x, emptying the values array');
+    return wait(7 * TimeUnits.MILLISECONDS).then(() => {
+      assert.equal(cachedGauge.toJSON(), 2);
+      assert.equal(values.length, 0, 'the callback should have been called 2x, emptying the values array');
+    });
   });
 
   afterEach(() => {

--- a/packages/measured-node-metrics/test/integration/test-express-middleware.js
+++ b/packages/measured-node-metrics/test/integration/test-express-middleware.js
@@ -42,24 +42,27 @@ describe('express-middleware', () => {
     registry.shutdown();
   });
 
-  it('creates a single timer that has 1 count for requests, when an http call is made once', async () => {
-    await callLocalHost(port, 'hello');
-
-    const registeredKeys = registry._registry.allKeys();
-    assert(registeredKeys.length === 1);
-    assert.equal(registeredKeys[0], 'requests-GET-200-/hello');
-    const metricWrapper = registry._registry.getMetricWrapperByKey('requests-GET-200-/hello');
-    const name = metricWrapper.name;
-    const dimensions = metricWrapper.dimensions;
-    assert.equal(name, 'requests');
-    assert.deepEqual(dimensions, { statusCode: '200', method: 'GET', uri: '/hello' });
+  it('creates a single timer that has 1 count for requests, when an http call is made once', () => {
+    return callLocalHost(port, 'hello').then(() => {
+      const registeredKeys = registry._registry.allKeys();
+      assert(registeredKeys.length === 1);
+      assert.equal(registeredKeys[0], 'requests-GET-200-/hello');
+      const metricWrapper = registry._registry.getMetricWrapperByKey('requests-GET-200-/hello');
+      const name = metricWrapper.name;
+      const dimensions = metricWrapper.dimensions;
+      assert.equal(name, 'requests');
+      assert.deepEqual(dimensions, { statusCode: '200', method: 'GET', uri: '/hello' });
+    });
   });
 
-  it('does not create runaway n metrics in the registry for n ids in the path', async () => {
-    await callLocalHost(port, 'users/foo');
-    await callLocalHost(port, 'users/bar');
-    await callLocalHost(port, 'users/bop');
-    assert.equal(registry._registry.allKeys().length, 1, 'There should only be one metric for /users and GET');
+  it('does not create runaway n metrics in the registry for n ids in the path', () => {
+    return Promise.all([
+      callLocalHost(port, 'users/foo'),
+      callLocalHost(port, 'users/bar'),
+      callLocalHost(port, 'users/bop')
+    ]).then(() => {
+      assert.equal(registry._registry.allKeys().length, 1, 'There should only be one metric for /users and GET');
+    });
   });
 });
 

--- a/packages/measured-node-metrics/test/unit/utils/test-CpuUtils.js
+++ b/packages/measured-node-metrics/test/unit/utils/test-CpuUtils.js
@@ -12,7 +12,7 @@ describe('CpuUtils', () => {
     assert(measure.total > 0);
   });
 
-  it('#calculateCpuUsagePercent calculates a percent', async () => {
+  it('#calculateCpuUsagePercent calculates a percent', () => {
     const start = CpuUtils.cpuAverage();
 
     for (let i = 0; i < 10000000; i++) {

--- a/packages/measured-reporting/test/unit/reporters/test-Reporter.js
+++ b/packages/measured-reporting/test/unit/reporters/test-Reporter.js
@@ -47,7 +47,7 @@ describe('Reporter', () => {
   it('throws an error if you try to instantiate the abstract class', () => {
     assert.throws(() => {
       new Reporter();
-    }, "Can't instantiate abstract class!");
+    }, /^TypeError: Can\'t instantiate abstract class\!$/);
   });
 
   it('throws an error if _reportMetrics is not implemented', () => {

--- a/packages/measured-reporting/test/unit/validators/test-inputValidators.js
+++ b/packages/measured-reporting/test/unit/validators/test-inputValidators.js
@@ -89,13 +89,13 @@ describe('validateMetric', () => {
   it('throws an error if the metric is undefined', () => {
     assert.throws(() => {
       validateMetric(undefined);
-    }, 'The metric was undefined, when it was required');
+    }, /^TypeError: The metric was undefined, when it was required$/);
   });
 
   it('throws an error if the metric is null', () => {
     assert.throws(() => {
       validateMetric(null);
-    }, 'The metric was undefined, when it was required');
+    }, /^TypeError: The metric was undefined, when it was required$/);
   });
 
   it('throws an error if toJSON is not a function', () => {


### PR DESCRIPTION
The `Object.values(...)` function was not added until Node.js 7.x. Use `Object.keys(...).map(...)` until the Node.js 6.x LTS expires.

Node.js 10.x+ also deprecated the use of a string matcher for the `assert.throws(...)` function, now throwing `ERR_AMBIGUOUS_ARGUMENT`.

All active release lines have been added to the `.travis.yml` to ensure complete test coverage.

Fixes #51