### PR TITLE
Add unrefTimers option to Reporter

### DIFF
--- a/packages/measured-reporting/lib/reporters/Reporter.js
+++ b/packages/measured-reporting/lib/reporters/Reporter.js
@@ -99,6 +99,15 @@ class Reporter {
      */
     this._defaultReportingIntervalInSeconds =
       options.defaultReportingIntervalInSeconds || DEFAULT_REPORTING_INTERVAL_IN_SECONDS;
+
+    /**
+     * Flag to indicate if reporting timers should be unref'd.
+     * If not overridden via the {@see ReporterOptions}, defaults to false.
+     *
+     * @type {boolean}
+     * @protected
+     */
+    this._unrefTimers = !!options.unrefTimers;
   }
 
   /**
@@ -142,11 +151,16 @@ class Reporter {
    */
   _createIntervalCallback(intervalInSeconds) {
     this._log.debug(`_createIntervalCallback() called with intervalInSeconds: ${intervalInSeconds}`);
-    this._intervals.push(
-      setInterval(() => {
-        this._reportMetricsWithInterval(intervalInSeconds);
-      }, intervalInSeconds * 1000)
-    );
+
+    const timer = setInterval(() => {
+      this._reportMetricsWithInterval(intervalInSeconds);
+    }, intervalInSeconds * 1000);
+
+    if (this._unrefTimers) {
+      timer.unref();
+    }
+
+    this._intervals.push(timer);
   }
 
   /**

--- a/packages/measured-reporting/lib/validators/inputValidators.js
+++ b/packages/measured-reporting/lib/validators/inputValidators.js
@@ -208,6 +208,11 @@ module.exports = {
     if (options) {
       module.exports.validateOptionalDimensions(options.defaultDimensions);
       module.exports.validateOptionalLogger(options.logger);
+
+      const type = typeof options.unrefTimers;
+      if (type !== 'boolean' && type !== 'undefined') {
+        throw new TypeError(`options.unrefTimers should be a boolean or undefined, actual type: ${type}`);
+      }
     }
   },
 

--- a/packages/measured-reporting/test/unit/reporters/test-Reporter.js
+++ b/packages/measured-reporting/test/unit/reporters/test-Reporter.js
@@ -124,6 +124,27 @@ describe('Reporter', () => {
 
     validateReporterInstance(anonymousReporter);
   });
+
+  it('unrefs timers, when configured to', () => {
+    let calledUnref = false;
+
+    const timer = setTimeout(() => {}, 100);
+    clearTimeout(timer);
+    const proto = timer.constructor.prototype;
+    const { unref } = proto;
+    proto.unref = function wrappedUnref() {
+      calledUnref = true;
+      return unref.call(this);
+    };
+
+    reporter = new TestReporter({ unrefTimers: true });
+    reporter.setRegistry(registry);
+    reporter.reportMetricOnInterval(metricKey, metricInterval);
+
+    proto.unref = unref;
+
+    assert.ok(calledUnref);
+  });
 });
 
 const reportAndWait = (reporter, metricKey, metricInterval) => {


### PR DESCRIPTION
The use of interval timers in the Reporter class causes the event loop to be held open even if there is no other activity. By using the unrefTimers option, those interval timers will now be unref'd so the event loop can exit when there are no other ref'd handles.