### PR TITLE
Defer initial report

### DIFF
--- a/packages/measured-reporting/lib/reporters/Reporter.js
+++ b/packages/measured-reporting/lib/reporters/Reporter.js
@@ -138,8 +138,10 @@ class Reporter {
       this._intervalToMetric[intervalInSeconds].add(metricKey);
     } else {
       this._intervalToMetric[intervalInSeconds] = new Set([metricKey]);
-      this._reportMetricsWithInterval(intervalInSeconds);
       this._createIntervalCallback(intervalInSeconds);
+      setImmediate(() => {
+        this._reportMetricsWithInterval(intervalInSeconds);
+      });
     }
   }
 


### PR DESCRIPTION
If adding several metrics at once, on the same interval, only the first will be reported in the initial report due to the immediate call to `reporter._reportMetricsWithInterval(...)`. By wrapping that in a `setImmediate(...)`, any other metrics set in that tick should now also be included in the initial report.