### PR TITLE
Report statusCode and uri accurately for POSTs

### DIFF
--- a/packages/measured-node-metrics/lib/nodeHttpRequestMetrics.js
+++ b/packages/measured-node-metrics/lib/nodeHttpRequestMetrics.js
@@ -26,7 +26,7 @@ module.exports = {
     return (req, res, next) => {
       const stopwatch = module.exports.onRequestStart();
 
-      req.on('end', () => {
+      res.on('finish', () => {
         const { method } = req;
         const { statusCode } = res;
         const uri = req.route ? req.route.path : '_unknown';

--- a/packages/measured-node-metrics/test/integration/test-express-middleware.js
+++ b/packages/measured-node-metrics/test/integration/test-express-middleware.js
@@ -21,6 +21,7 @@ describe('express-middleware', () => {
       middleware = createExpressMiddleware(registry, 1);
       app = express();
       app.use(middleware);
+      app.use(express.json());
 
       app.get('/hello', (req, res) => res.send('Hello World!'));
       app.post('/world', (req, res) => res.status(201).send('Hello World!'));
@@ -57,7 +58,8 @@ describe('express-middleware', () => {
   });
 
   it('creates a single timer that has 1 count for requests, when an http POST call is made once', () => {
-    return callLocalHost(port, 'world', 'POST').then(() => {
+    const options = {method: 'POST', headers: {'Content-Type': 'application/json'}};
+    return callLocalHost(port, 'world', options).then(() => {
       const registeredKeys = registry._registry.allKeys();
       assert(registeredKeys.length === 1);
       assert.equal(registeredKeys[0], 'requests-POST-201-/world');
@@ -80,10 +82,16 @@ describe('express-middleware', () => {
   });
 });
 
-const callLocalHost = (port, endpoint, method) => {
+const callLocalHost = (port, endpoint, options) => {
   return new Promise((resolve, reject) => {
+    const req = Object.assign({protocol: `http:`,
+                                   host: `127.0.0.1`,
+                                   port: `${port}`,
+                                   path: `/${endpoint}`,
+                                   method: 'GET'},
+                                  options || {});
     http
-      .request({protocol: `http:`, host: `127.0.0.1`, port: `${port}`, path: `/${endpoint}`, 'method': (method || 'GET')}, resp => {
+      .request(req, resp => {
         let data = '';
         resp.on('data', chunk => {
           data += chunk;

--- a/packages/measured-node-metrics/test/unit/test-nodeHttpRequestMetrics.js
+++ b/packages/measured-node-metrics/test/unit/test-nodeHttpRequestMetrics.js
@@ -6,15 +6,14 @@ const { createExpressMiddleware, onRequestStart, onRequestEnd } = require('../..
 const TestReporter = require('./TestReporter');
 const Registry = require('measured-reporting').SelfReportingMetricsRegistry;
 
-class MockRequest extends EventEmitter {
+class MockResponse extends EventEmitter {
   constructor() {
     super();
-    this.method = 'GET';
-    this.path = '/v1/rest/some-end-point';
+    this.statusCode = 200;
   }
 
-  end() {
-    this.emit('end');
+  finish() {
+    this.emit('finish');
   }
 }
 
@@ -52,15 +51,16 @@ describe('createExpressMiddleware', () => {
 
     const middleware = createExpressMiddleware(registry);
 
-    const req = new MockRequest();
+    const res = new MockResponse();
     middleware(
-      req,
       {
-        statusCode: 200
+        method: 'GET',
+        routine: {path: '/v1/rest/some-end-point'}
       },
+      res,
       () => {}
     );
-    req.end();
+    res.finish();
 
     const registeredKeys = registry._registry.allKeys();
     assert(registeredKeys.length === 1);

--- a/tutorials/SignalFx Express Full End to End Example.md
+++ b/tutorials/SignalFx Express Full End to End Example.md
@@ -4,6 +4,8 @@ This tutorial shows how to use the measured libraries to fully instrument OS and
 
 The middleware will measure request count, latency distributions (req/res time histogram) and add dimensions to make it filterable by request method, response status code, request uri path.
 
+**NOTE:** You must add `app.use(createExpressMiddleware(...))` **before** the use of any express bodyParsers like `app.use(express.json())` because requests that are first handled by a bodyParser will not get measured.
+
 ```javascript
 const os = require('os');
 const signalfx = require('signalfx');


### PR DESCRIPTION
With a listener on the `req.on('end')` event, `req.route` and `res.statusCode` are undefined. Switching to `res.on('finish')` makes these values available.

https://github.com/yaorg/node-measured/issues/57