### PR TITLE
 feat: The sendEvent wrapper now returns a promise

### DIFF
--- a/packages/measured-signalfx-reporter/lib/registries/SignalFxSelfReportingMetricsRegistry.js
+++ b/packages/measured-signalfx-reporter/lib/registries/SignalFxSelfReportingMetricsRegistry.js
@@ -71,9 +71,11 @@ class SignalFxSelfReportingMetricsRegistry extends SelfReportingMetricsRegistry 
    */
   sendEvent(eventType, category, dimensions, properties, timestamp) {
     return Promise.all(
-      this._reporters
-        .filter(reporter => typeof reporter.sendEvent === 'function')
-        .map(reporter => reporter.sendEvent(eventType, category, dimensions, properties, timestamp))
+      this._reporters.filter(reporter => typeof reporter.sendEvent === 'function').map(reporter =>
+        reporter.sendEvent(eventType, category, dimensions, properties, timestamp).catch(error => {
+          return error;
+        })
+      )
     );
   }
 }

--- a/packages/measured-signalfx-reporter/lib/registries/SignalFxSelfReportingMetricsRegistry.js
+++ b/packages/measured-signalfx-reporter/lib/registries/SignalFxSelfReportingMetricsRegistry.js
@@ -70,11 +70,9 @@ class SignalFxSelfReportingMetricsRegistry extends SelfReportingMetricsRegistry 
    * registry.sendEvent('uncaughtException', SignalFxEventCategories.ALERT);
    */
   sendEvent(eventType, category, dimensions, properties, timestamp) {
-    return this._reporters.forEach(reporter => {
-      if (typeof reporter.sendEvent === 'function') {
-        reporter.sendEvent(eventType, category, dimensions, properties, timestamp);
-      }
-    });
+    return Promise.all(this._reporters
+      .filter(reporter => typeof reporter.sendEvent === 'function')
+      .map(reporter => reporter.sendEvent(eventType, category, dimensions, properties, timestamp)));
   }
 }
 

--- a/packages/measured-signalfx-reporter/lib/registries/SignalFxSelfReportingMetricsRegistry.js
+++ b/packages/measured-signalfx-reporter/lib/registries/SignalFxSelfReportingMetricsRegistry.js
@@ -70,9 +70,11 @@ class SignalFxSelfReportingMetricsRegistry extends SelfReportingMetricsRegistry 
    * registry.sendEvent('uncaughtException', SignalFxEventCategories.ALERT);
    */
   sendEvent(eventType, category, dimensions, properties, timestamp) {
-    return Promise.all(this._reporters
-      .filter(reporter => typeof reporter.sendEvent === 'function')
-      .map(reporter => reporter.sendEvent(eventType, category, dimensions, properties, timestamp)));
+    return Promise.all(
+      this._reporters
+        .filter(reporter => typeof reporter.sendEvent === 'function')
+        .map(reporter => reporter.sendEvent(eventType, category, dimensions, properties, timestamp))
+    );
   }
 }
 


### PR DESCRIPTION
In the SignalFx library `sendEvent` is async and returns a promise. In the
`SignalFxSelfReportingMetricsRegistry`, the `sendEvent` wrapper always
returned `undefined` (since it was returning the result of `forEach`). So
there was no way to track when it was done.

Here's the source for the SignalFx client `sendEvent`:
https://github.com/signalfx/signalfx-nodejs/blob/master/lib/client/ingest/signal_fx_client.js#L167