### PR TITLE
feat: Add optional `keepAlive` option to Meter and Timer

### DIFF
--- a/packages/measured-core/lib/metrics/Meter.js
+++ b/packages/measured-core/lib/metrics/Meter.js
@@ -22,6 +22,10 @@ class Meter {
   constructor(properties) {
     this._properties = properties || {};
     this._initializeState();
+
+    if (!this._properties.keepAlive) {
+      this.unref();
+    }
   }
 
   /**
@@ -164,6 +168,7 @@ module.exports = Meter;
  * @type {Object}
  * @property {number} rateUnit The rate unit. Defaults to 1000 (1 sec).
  * @property {number} tickInterval The interval in which the averages are updated. Defaults to 5000 (5 sec).
+ * @property {boolean} keepAlive Optional flag to unref the associated timer. Defaults to `false`.
  * @example
  * const meter = new Meter({ rateUnit: 1000, tickInterval: 5000})
  */

--- a/packages/measured-core/lib/metrics/Timer.js
+++ b/packages/measured-core/lib/metrics/Timer.js
@@ -43,6 +43,11 @@ class Timer {
     this._meter = properties.meter || new Meter({});
     this._histogram = properties.histogram || new Histogram({});
     this._getTime = properties.getTime;
+    this._keepAlive = !!properties.keepAlive;
+
+    if (!properties.keepAlive) {
+      this.unref();
+    }
   }
 
   /**
@@ -127,4 +132,5 @@ module.exports = Timer;
  * @property {Meter} meter The internal meter to use. Defaults to a new {@link Meter}.
  * @property {Histogram} histogram The internal histogram to use. Defaults to a new {@link Histogram}.
  * @property {function} getTime optional function override for supplying time to the {@link Stopwatch}
+ * @property {boolean} keepAlive Optional flag to unref the associated timer. Defaults to `false`.
  */

--- a/packages/measured-reporting/lib/reporters/Reporter.js
+++ b/packages/measured-reporting/lib/reporters/Reporter.js
@@ -92,7 +92,8 @@ class Reporter {
      * @type {Logger}
      * @protected
      */
-    this._log = options.logger || consoleLogLevel({ name: 'Reporter', level: options.logLevel || 'info', prefix: prefix });
+    this._log =
+      options.logger || consoleLogLevel({ name: 'Reporter', level: options.logLevel || 'info', prefix: prefix });
 
     /**
      * The default reporting interval, a number in seconds.


### PR DESCRIPTION
This PR unrefs timers by default, eliminating headaches for people unsure about why their unit tests keep hanging.

It also eliminates having to break a 1 line piece of code into 3:
```
// no unref-ing
collection.meter('responses').mark()

// with unref-ing
const responsesMeter = collection.meter('responses');
responsesMeter.unref();
responsesMeter.mark();

// with PR, keepAlive = false
collection.meter('responses').mark()

// with PR, keepAlive = true
collection.meter('responses', {keepAlive: true}).mark()
```

I've set the default to `false` since that was most helpful for my team. However, I could be convinced to have it default to `true`.