### PR TITLE
feat(signalfx-reporter): add additional debug logging

### DIFF
--- a/packages/measured-signalfx-reporter/lib/reporters/SignalFxMetricsReporter.js
+++ b/packages/measured-signalfx-reporter/lib/reporters/SignalFxMetricsReporter.js
@@ -13,9 +13,12 @@ class SignalFxMetricsReporter extends Reporter {
    * @param {ReporterOptions} [options] See {@link ReporterOptions}.
    */
   constructor(signalFxClient, options) {
+    options = options || {};
     super(options);
     validateSignalFxClient(signalFxClient);
     this._signalFxClient = signalFxClient;
+
+    this._log.debug(`SignalFx Metrics Reporter Created with the following default default reporting interval: ${options.defaultReportingIntervalInSeconds}, default dimensions: ${JSON.stringify(options.defaultDimensions, null, 2)}`);
   }
 
   /**
@@ -36,7 +39,7 @@ class SignalFxMetricsReporter extends Reporter {
       signalFxDataPointRequest = this._processMetric(metric, signalFxDataPointRequest);
     });
 
-    this._log.debug('Sending data to Signal Fx');
+    this._log.debug(`Sending data to Signal Fx. Request: ${JSON.stringify(signalFxDataPointRequest)}`);
 
     this._signalFxClient.send(signalFxDataPointRequest).catch(error => {
       this._log.error('Failed to send metrics to signal fx error:', error);


### PR DESCRIPTION
Adding some new debug statements for the SignalFx reporter to enable easier prod support.

EX: from UAT

```bash
AP77JGH6A84FA3:node-measured jfiel2$ node packages/measured-signalfx-reporter/test/user-acceptance-test/index.js 
2019-08-28T22:51:45.646Z:  SignalFx Metrics Reporter Created with the following default default reporting interval: 10, default dimensions: {
  "app": "measured-signalfx-reporter",
  "app_version": "1.50.0",
  "env": "test"
}
2019-08-28T22:51:45.649Z:  _createIntervalCallback() called with intervalInSeconds: 30
Example app listening on port 8080!
2019-08-28T22:51:45.665Z:  _reportMetricsWithInterval() called with intervalInSeconds: 30
2019-08-28T22:51:45.665Z:  _reportMetrics() called
2019-08-28T22:51:45.666Z:  Sending data to Signal Fx. Request: {"gauges":[{"metric":"node.os.loadavg.1m","value":2.26171875,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}},{"metric":"node.os.loadavg.5m","value":2.443359375,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}},{"metric":"node.os.loadavg.15m","value":2.330078125,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}},{"metric":"node.os.freemem","value":7081623552,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}},{"metric":"node.os.totalmem","value":34359738368,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}},{"metric":"node.os.uptime","value":109451,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}},{"metric":"node.os.cpu.all-cores-avg","value":31,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}},{"metric":"node.process.memory-usage.rss","value":61145088,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}},{"metric":"node.process.memory-usage.heap-total","value":35401728,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}},{"metric":"node.process.memory-usage.heap-used","value":21408856,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}},{"metric":"node.process.memory-usage.external","value":550020,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}},{"metric":"node.process.uptime","value":0,"dimensions":{"app":"measured-signalfx-reporter","app_version":"1.50.0","env":"test"}}]}
^CSIG INT, exiting
```